### PR TITLE
Explicity set notify parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@
 var Notify = require('notifyjs'),
     jQuery = window.jQuery;
 
+jQuery.notify = Notify;
+
 if (!jQuery.notify) {
     throw new Error('jquery notifyjs plugin not found');
 }

--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
   "author": "cdaringe",
   "license": "MIT",
   "dependencies": {
-    "notifyjs": "^1.2.8"
+    "notifyjs": "^3.0.0"
   },
   "devDependencies": {
     "browserify": "^10.2.0",
     "domready": "^1.0.8",
-    "jquery": "^2.1.4",
+    "jquery": "^3.3.1",
     "precommit-hook": "^2.0.1",
     "tape": "^4.0.0",
     "testem": "^0.9.8"


### PR DESCRIPTION
After upgrading to jQuery 3.3.1 and notifyjs 3.0.0, coins-notify no longer works as expected.